### PR TITLE
Automatic dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.3] - 2025-09-24
+### Changed
+- Updated min sdk version to ^3.9.0
+- Updated dependencies
+
 ## [1.0.2] - 2025-08-17
 ### Changed
 - Updated dependencies
@@ -16,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Initial release
 
+[1.0.3]: https://github.com/Skycoder42/bw-pinentry/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/Skycoder42/bw-pinentry/compare/v1.0.1...v1.0.2
 [1.0.1]: https://github.com/Skycoder42/bw-pinentry/compare/v1.0.0...v1.0.1
 [1.0.0]: https://github.com/Skycoder42/bw-pinentry/releases/tag/v1.0.0

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: bw_pinentry
 description: A pinentry wrapper around the bitwarden CLI to use your vault for GPG-Key storage.
-version: 1.0.2
+version: 1.0.3
 repository: https://github.com/Skycoder42/bw-pinentry
 publish_to: none
 
@@ -21,12 +21,12 @@ dependencies:
   stream_channel: ^2.1.4
 
 dev_dependencies:
-  build_runner: ^2.7.0
+  build_runner: ^2.7.1
   custom_lint: ^0.8.0
-  dart_pre_commit: ^5.4.8
+  dart_pre_commit: ^6.0.0
   dart_test_tools: ^6.2.2
-  freezed: ^3.2.0
-  json_serializable: ^6.10.0
+  freezed: ^3.2.3
+  json_serializable: ^6.11.1
 
 aur:
   maintainer: Skycoder42 <Skycoder42@users.noreply.github.com>


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for bw_pinentry to ^3.9.0
### Dependency Updates
```

Changed 4 constraints in pubspec.yaml:
  dart_pre_commit: ^5.4.8 -> ^6.0.0
  build_runner: ^2.7.0 -> ^2.7.1
  freezed: ^3.2.0 -> ^3.2.3
  json_serializable: ^6.10.0 -> ^6.11.1
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 85.0.0 (89.0.0 available)
  analyzer 7.6.0 (8.2.0 available)
  analyzer_plugin 0.13.4 (0.13.8 available)
  build 3.1.0 (4.0.0 available)
  build_resolvers 3.0.3 (3.0.4 available)
  build_runner 2.7.1 (2.8.0 available)
  build_runner_core 9.3.1 (9.3.2 available)
  custom_lint 0.8.0 (0.8.1 available)
  custom_lint_builder 0.8.0 (0.8.1 available)
  custom_lint_core 0.8.0 (0.8.1 available)
  custom_lint_visitor 1.0.0+7.7.0 (1.0.0+8.1.1 available)
> dart_pre_commit 6.0.0 (was 5.4.8)
  dart_style 3.1.1 (3.1.2 available)
+ get_it 8.2.0
+ injectable 2.5.1
  source_gen 4.0.0 (4.0.1 available)
These packages are no longer being depended on:
- riverpod 2.6.1
- state_notifier 1.0.0
Changed 5 dependencies!
13 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
