### PR TITLE
Automatic dependency updates

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.0.5] - 2026-02-18
+### Changed
+- Updated min sdk version to ^3.11.0
+- Updated dependencies
+
 ## [1.0.4] - 2025-12-03
 ### Changed
 - Updated min sdk version to ^3.10.0
@@ -26,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Initial release
 
+[1.0.5]: https://github.com/Skycoder42/bw-pinentry/compare/v1.0.4...v1.0.5
 [1.0.4]: https://github.com/Skycoder42/bw-pinentry/compare/v1.0.3...v1.0.4
 [1.0.3]: https://github.com/Skycoder42/bw-pinentry/compare/v1.0.2...v1.0.3
 [1.0.2]: https://github.com/Skycoder42/bw-pinentry/compare/v1.0.1...v1.0.2

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,11 +1,11 @@
 name: bw_pinentry
 description: A pinentry wrapper around the bitwarden CLI to use your vault for GPG-Key storage.
-version: 1.0.4
+version: 1.0.5
 repository: https://github.com/Skycoder42/bw-pinentry
 publish_to: none
 
 environment:
-  sdk: ^3.10.0
+  sdk: ^3.11.0
 
 platforms:
   linux:
@@ -16,16 +16,16 @@ executables:
 dependencies:
   async: ^2.13.0
   freezed_annotation: ^3.1.0
-  json_annotation: ^4.9.0
-  meta: ^1.17.0
+  json_annotation: ^4.10.0
+  meta: ^1.18.1
   stream_channel: ^2.1.4
 
 dev_dependencies:
-  build_runner: ^2.10.4
+  build_runner: ^2.11.1
   dart_pre_commit: ^6.1.0
   dart_test_tools: ^7.0.1
-  freezed: ^3.2.3
-  json_serializable: ^6.11.2
+  freezed: ^3.2.5
+  json_serializable: ^6.12.0
 
 aur:
   maintainer: Skycoder42 <Skycoder42@users.noreply.github.com>


### PR DESCRIPTION
### SDK Updates
- Settings sdk version for bw_pinentry to ^3.11.0
### Dependency Updates
```

Changed 5 constraints in pubspec.yaml:
  json_annotation: ^4.9.0 -> ^4.10.0
  meta: ^1.17.0 -> ^1.18.1
  build_runner: ^2.10.4 -> ^2.11.1
  freezed: ^3.2.3 -> ^3.2.5
  json_serializable: ^6.11.2 -> ^6.12.0
Resolving dependencies...
Downloading packages...
  _fe_analyzer_shared 92.0.0 (95.0.0 available)
  analysis_server_plugin 0.3.4 (0.3.9 available)
  analyzer 9.0.0 (10.1.0 available)
  analyzer_plugin 0.13.11 (0.14.3 available)
  dart_style 3.1.3 (3.1.5 available)
No dependencies changed.
5 packages have newer versions incompatible with dependency constraints.
Try `flutter pub outdated` for more information.
```
